### PR TITLE
Update `urllib3` version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "elasticsearch-dsl",
     "elastic-transport",
     "doccano-client",
-    "urllib3==1.26"     
+    "urllib3"     
 ]
 
 [build-system]


### PR DESCRIPTION
Relax `urllib3` version - this breaks the install.