### PR TITLE
iss30_refactored

### DIFF
--- a/projects/local_synth_brca/main.py
+++ b/projects/local_synth_brca/main.py
@@ -5,30 +5,6 @@ import os
 from bioext.elastic_utils import ElasticsearchSession
 from bioext.doccano_utils import DoccanoSession, load_from_file, stream_labelled_docs
 from dotenv import load_dotenv
-import yaml
-from datetime import datetime, timezone
-
-# this is a name of the file to write capturing Doccano project id and time
-
-yaml_output_file = "projectid.yaml"
-
-def write_yaml(data,yaml_output_file):
-    """this function check if yaml file alraedy exists, if not will write a yaml file 
-    at the destination given by arguments
-    Args:
-        data (dict): variables as dict to write
-        yaml_output_file (str): object to be written.
-    """
-    if os.path.exists(yaml_output_file):
-        print(f"{yaml_output_file} already exists; Nothing is done.")
-    else:
-        try:
-            with open(yaml_output_file,'w') as f:
-                yaml.dump(data,f,sort_keys=False, default_flow_style=False)
-            print(f"{yaml_output_file} has been written successfully.")
-        except Exception as e:
-            print(f"An error on writing to {yaml_output_file}: {e}")
-        
 
 def parse_CLI_args():  # -> argparse.Namespace:
     """Parse command line arguments
@@ -191,18 +167,6 @@ def es2doc(config, sample_size=100):
 
     print(f"Success: {successful_loads}")
     print(f"Failed: {failed_loads}")
-    
-    # create timestamp
-    
-    # generate time 
-    formatted_datetime = datetime.now().astimezone().strftime("%d-%m-%Y %H:%M:%S %Z%z")
-
-    doccano_proj_details = {
-        "Doccano Project name": project.name,
-        "Doccano Project ID": project.id,
-        "Project creation Time": formatted_datetime,
-    }
-    return doccano_proj_details
 
 
 if __name__ == "__main__":
@@ -241,7 +205,6 @@ if __name__ == "__main__":
 
         elif args.subcommand == "ES2Doc":
             doccano_details = es2doc(app_config, args.sample_size)
-            write_yaml(doccano_details,yaml_output_file)
 
     elif args.subcommand.startswith("Doc"):
         # Initialise connection to Doccano

--- a/projects/local_synth_brca/main.py
+++ b/projects/local_synth_brca/main.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
             )
 
         elif args.subcommand == "ES2Doc":
-            doccano_details = es2doc(app_config, args.sample_size)
+            es2doc(app_config, args.sample_size)
 
     elif args.subcommand.startswith("Doc"):
         # Initialise connection to Doccano

--- a/src/bioext/doccano_utils.py
+++ b/src/bioext/doccano_utils.py
@@ -27,7 +27,7 @@ class DoccanoSession:
         """this internal method will save project metadata as yaml at project root
 
         Args:
-            project (object): object which is an output of create_or_update method
+            project (Doccano project object): object which is an output of create_or_update method
             filepath (str, optional): name and path to save. Defaults to "projectid.yaml".
         """
         formatted_datetime = datetime.now().astimezone().strftime("%d-%m-%Y %H:%M:%S %Z%z")

--- a/src/bioext/doccano_utils.py
+++ b/src/bioext/doccano_utils.py
@@ -1,6 +1,5 @@
 import os
 import json
-import functools
 from doccano_client import DoccanoClient
 from datetime import datetime
 import yaml


### PR DESCRIPTION
Previously, function that writes doccano project metadata as variables is in `projects/local_synth_brca/main.py`.

This function is now refactored as a `save_metadata` decorator. It is written in a way that even if save_metadata function errors for whatever reason the project creation can continue. (Do we want differently?)

The `create_or_update_project` method from Doccano session class has a decorator.

I have done tests on individual code blocks and also the whole thing runs seamlessly. 
Hope this helps. 


